### PR TITLE
Only keep the most recent build artifacts in the cache.

### DIFF
--- a/lib/assets.sh
+++ b/lib/assets.sh
@@ -3,6 +3,13 @@ function save_assets() {
   local cache_dir="$2"
 
   if [ -d "$save_dir" ]; then
+    echo "- preparing to cache $save_dir to $cache_dir but clearing destination first"
+    rm -fr "$cache_dir"
+
+    echo "- removed $cache_dir checking size on disk"
+    mkdir -p "$cache_dir"
+    du -sh "$cache_dir"
+
     echo "- caching $save_dir"
     du -sh "$save_dir"
     mkdir -p "$cache_dir"

--- a/lib/assets.sh
+++ b/lib/assets.sh
@@ -6,10 +6,6 @@ function save_assets() {
     echo "- preparing to cache $save_dir to $cache_dir but clearing destination first"
     rm -fr "$cache_dir"
 
-    echo "- removed $cache_dir checking size on disk"
-    mkdir -p "$cache_dir"
-    du -sh "$cache_dir"
-
     echo "- caching $save_dir"
     du -sh "$save_dir"
     mkdir -p "$cache_dir"


### PR DESCRIPTION
# What does this PR do?

This change-set updates the buildpack to only keep the most recent build artifacts in the cache.

- This clears the destination cache directory before saving/caching to it.
- Print out the results cache_dir size after removal to communicate whether or not the cache dir was successfully cleared.

Below is the exact steps and process used for verifying this fix through numerous deploys. The TL;DR of it all is that the cache directory size is no longer growing like weeds with each deploy.

## Test Plan

- [x] Test on deploys in sandbox app
- [x] Test on staging deploys

## Test Plan: Prepare for running a series of deployments on rapgenius-staging

### Get list of buildpacks:

```bash
heroku buildpacks -a rapgenius-staging
```

Output:
```bash
=== rapgenius-staging Buildpack URLs
1. heroku/jvm
2. https://github.com/Genius/heroku-gsl-buildpack.git#1d8b938151dcf3e4975d4f16723d1cf22acad343
3. https://github.com/heroku/heroku-buildpack-nginx.git
4. https://github.com/heroku/heroku-buildpack-pgbouncer.git#v0.3.4
5. https://github.com/Genius/heroku-buildpack-phantomjs.git
6. https://github.com/heroku/heroku-buildpack-nodejs.git#v126
7. https://github.com/heroku/heroku-buildpack-ruby.git#v200
8. https://github.com/Genius/heroku-buildpack-compile-tasks.git
```

The cache buildpack is currently not in use, so add them:

```bash
heroku buildpacks:add --index 1 https://github.com/Genius/cache_rails_assets_buildpack.git#v5-restore_rails_assets -a rapgenius-staging

heroku buildpacks:add https://github.com/Genius/cache_rails_assets_buildpack.git#v5-save_rails_assets -a rapgenius-staging
```


```bash
 puts File.read('/tmp/activity.txt').lines.join(" ").scan(/Deployed (\w+).*?(v\d+)/m)[0..33].select { |sha,ver| `git branch --contains #{sha} | grep -v rails-3-2` ; $?.exitstatus == 1 }.map{ |sha,ver| "#{ver} #{sha}" }
```

### Determine what to deploy

Look at the last 50 distinct deploys (e.g. ignore builds that were due to configuration changes). This gives us:

```bash
v5967 ffbf3fbf
v5966 cd0cf269
v5965 7773d628
v5964 548468a7
v5963 2f557b18
v5962 09300f69
v5960 26e25778
v5959 f943e689
v5958 bcba4b69
v5954 78e5cd87
v5950 c058693e
v5949 bcba4b69
v5945 24474908
v5944 e7ed2b11
v5940 bcba4b69
v5939 04a0331a
v5935 bcba4b69
v5934 1353f852
v5933 9a94fa95
v5929 bcba4b69
v5928 ddd046ed
v5925 36a3faa6
v5921 ddd046ed
v5920 42323be1
v5919 9ea02764
v5916 07cff7bc
v5915 0d8365b6
v5914 0c83f472
v5913 1fa26b07
v5910 9ea02764
v5909 0cfe4f0f
v5906 dfaf1241
v5903 0cfe4f0f
v5901 7f21aaa6
```

Filter the list down to only Rails 2 deploys, ignore all Rails 3 deploys:

```bash
v5967 ffbf3fbf
v5966 cd0cf269
v5965 7773d628
v5964 548468a7
v5963 2f557b18
v5954 78e5cd87
v5950 c058693e
v5945 24474908
v5944 e7ed2b11
v5939 04a0331a
v5934 1353f852
v5933 9a94fa95
v5925 36a3faa6
v5916 07cff7bc
v5915 0d8365b6
v5914 0c83f472
v5913 1fa26b07
v5906 dfaf1241
```

Further filter the list down to only Rails 2 deploys that included stylesheet changes:

```bash
v5966 cd0cf269
v5965 7773d628
v5964 548468a7
v5963 2f557b18
```

### Purge the cache before deploy:

```bash
heroku repo:purge_cache -a rapgenius-staging
```

### Deploy the deploy in oldest first order

#### Deploying 2f557b18 (v5963)

```bash
# v5963
time git push heroku 2f557b18:master
```

Before this deploy, the assets cache was empty so no restore happened.

After this deploy, these asset directories were cached:

```bash
remote: 79M	/tmp/build_b188df7f594e67aae2642d8b2d93f50e/tmp/assets
remote: 4.9M	/tmp/build_b188df7f594e67aae2642d8b2d93f50e/tmp/javascripts
remote: 11M	/tmp/build_b188df7f594e67aae2642d8b2d93f50e/tmp/sass
remote: 36K	/tmp/build_b188df7f594e67aae2642d8b2d93f50e/tmp/sass-preprocessed
remote: 48M	/tmp/build_b188df7f594e67aae2642d8b2d93f50e/tmp/sprockets-cache
remote: 796K	/tmp/build_b188df7f594e67aae2642d8b2d93f50e/tmp/templates
```

This deploy took 23m52s.

#### Deploying 548468a7 (v5964)

```bash
# v5964
time git push heroku 548468a7:master
```

Before this deploy, the following asset directories were restored:  

```bash
remote: 79M	/app/tmp/cache/rails/cache/assets
remote: 4.9M	/app/tmp/cache/rails/cache/javascripts
remote: 11M	/app/tmp/cache/rails/cache/sass
remote: 36K	/app/tmp/cache/rails/cache/sass-preprocessed
remote: 48M	/app/tmp/cache/rails/cache/sprockets-cache
remote: 796K	/app/tmp/cache/rails/cache/templates
```

After this deploy, these asset directories were cached:

```bash
remote: 78M	/tmp/build_cc97a3a07028942f150b85ab897eeb8a/tmp/assets
remote: 4.9M	/tmp/build_cc97a3a07028942f150b85ab897eeb8a/tmp/javascripts
remote: 11M	/tmp/build_cc97a3a07028942f150b85ab897eeb8a/tmp/sass
remote: 36K	/tmp/build_cc97a3a07028942f150b85ab897eeb8a/tmp/sass-preprocessed
remote: 48M	/tmp/build_cc97a3a07028942f150b85ab897eeb8a/tmp/sprockets-cache
remote: 796K	/tmp/build_cc97a3a07028942f150b85ab897eeb8a/tmp/templates
```

This deploy took 14m26s.

#### Deploying 7773d628 (v5965)

```bash
# v5965
time git push heroku 7773d628:master
```

Before this deploy, the following asset directories were restored:  

```bash
remote: 78M	/app/tmp/cache/rails/cache/assets
remote: 4.9M	/app/tmp/cache/rails/cache/javascripts
remote: 11M	/app/tmp/cache/rails/cache/sass
remote: 36K	/app/tmp/cache/rails/cache/sass-preprocessed
remote: 48M	/app/tmp/cache/rails/cache/sprockets-cache
remote: 796K	/app/tmp/cache/rails/cache/templates
```

After this deploy, these asset directories were cached:

```bash
remote: 79M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/assets
remote: 4.9M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/javascripts
remote: 11M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/sass
remote: 36K	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/sass-preprocessed
remote: 48M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/sprockets-cache
remote: 796K	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/templates
```

This deploy took 14m55s.

#### Deploying cd0cf269 (v5966)

```bash
# v5966
time git push heroku cd0cf269:master
```

Before this deploy, the following asset directories were restored:  

```bash
remote: 79M	/app/tmp/cache/rails/cache/assets
remote: 4.9M	/app/tmp/cache/rails/cache/javascripts
remote: 11M	/app/tmp/cache/rails/cache/sass
remote: 36K	/app/tmp/cache/rails/cache/sass-preprocessed
remote: 48M	/app/tmp/cache/rails/cache/sprockets-cache
remote: 796K	/app/tmp/cache/rails/cache/templates
```

After this deploy, these asset directories were cached:

```bash
remote: 79M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/assets
remote: 4.9M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/javascripts
remote: 11M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/sass
remote: 36K	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/sass-preprocessed
remote: 48M	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/sprockets-cache
remote: 796K	/tmp/build_23c4a9d87dbbfb7458b9e7913b376540/tmp/templates
```

This deploy took 16m14s.

### Preparing for Rails 3 deploys

#### Replace the ruby buildpack for `BUNDLE_GEMFILE` support

```bash
heroku buildpacks:remove https://github.com/heroku/heroku-buildpack-ruby.git#v200
```

```bash
heroku buildpacks:add \
  --index 8 \
  https://github.com/Genius/heroku-buildpack-ruby.git#enable-bundle-gemfile-with-1.15.2 \
  -a rapgenius-staging
```

#### Set environment variables

```bash
heroku config:set \
  BUNDLE_GEMFILE=gemfiles/rails_3.gemfile \
  ENABLE_RAILS_3_UNFINISHED_MAILER_IMPLEMENTATION=true \
  PGBOUNCER_PREPARED_STATEMENTS=false \
  ENABLE_UNSAFE_VESTAL_VERSIONS_2=true \
  -a rapgenius-staging
```

#### Deploying Rails 3

```bash
time git push -f heroku rails-3-2/integration-for-circle-ci:master
```

Before this deploy, the following asset directories were restored:  

```bash
remote: 79M	/app/tmp/cache/rails/cache/assets
remote: 4.9M	/app/tmp/cache/rails/cache/javascripts
remote: 11M	/app/tmp/cache/rails/cache/sass
remote: 36K	/app/tmp/cache/rails/cache/sass-preprocessed
remote: 48M	/app/tmp/cache/rails/cache/sprockets-cache
remote: 796K	/app/tmp/cache/rails/cache/templates
```

After this deploy, these asset directories were cached:

```bash
remote: 98M	/tmp/build_986c2cb2b18e6035f9be42f10a7e6e74/tmp/assets
remote: 4.9M	/tmp/build_986c2cb2b18e6035f9be42f10a7e6e74/tmp/javascripts
remote: 11M	/tmp/build_986c2cb2b18e6035f9be42f10a7e6e74/tmp/sass
remote: 36K	/tmp/build_986c2cb2b18e6035f9be42f10a7e6e74/tmp/sass-preprocessed
remote: 87M	/tmp/build_986c2cb2b18e6035f9be42f10a7e6e74/tmp/sprockets-cache
remote: 796K	/tmp/build_986c2cb2b18e6035f9be42f10a7e6e74/tmp/templates
```

This deploy took 17m38s.

#### Deploying Rails 3 a second time

```bash
time git push -f heroku rails-3-2/integration-for-circle-ci^:master
```

Before this deploy, the following asset directories were restored:  

```bash
remote: 98M	/app/tmp/cache/rails/cache/assets
remote: 4.9M	/app/tmp/cache/rails/cache/javascripts
remote: 11M	/app/tmp/cache/rails/cache/sass
remote: 36K	/app/tmp/cache/rails/cache/sass-preprocessed
remote: 87M	/app/tmp/cache/rails/cache/sprockets-cache
remote: 796K	/app/tmp/cache/rails/cache/templates
```

After this deploy, these asset directories were cached:

```bash
remote: 98M	/tmp/build_d7d09c7bcbe08dba8685642c142e5ce5/tmp/assets
remote: 4.9M	/tmp/build_d7d09c7bcbe08dba8685642c142e5ce5/tmp/javascripts
remote: 11M	/tmp/build_d7d09c7bcbe08dba8685642c142e5ce5/tmp/sass
remote: 36K	/tmp/build_d7d09c7bcbe08dba8685642c142e5ce5/tmp/sass-preprocessed
remote: 87M	/tmp/build_d7d09c7bcbe08dba8685642c142e5ce5/tmp/sprockets-cache
remote: 796K	/tmp/build_d7d09c7bcbe08dba8685642c142e5ce5/tmp/templates
```

This deploy took 16m27s.

### Back to deploying Rails 2

#### Restore the previous ruby buildpack 

```bash
heroku buildpacks:remove https://github.com/Genius/heroku-buildpack-ruby.git#enable-bundle-gemfile-with-1.15.2 -a rapgenius-staging
```

```bash
heroku buildpacks:add --index 8 https://github.com/heroku/heroku-buildpack-ruby.git#v200
```

#### Set environment variables

```bash
heroku config:unset \
  BUNDLE_GEMFILE \
  ENABLE_RAILS_3_UNFINISHED_MAILER_IMPLEMENTATION \
  PGBOUNCER_PREPARED_STATEMENTS \
  ENABLE_UNSAFE_VESTAL_VERSIONS_2 \
  -a rapgenius-staging
```

#### Deploying ffbf3fbf (v5967)

```bash
# v5966
time git push heroku ffbf3fbf:master
```

Before this deploy, the following asset directories were restored:  

```bash
remote: 98M	/app/tmp/cache/rails/cache/assets
remote: 4.9M	/app/tmp/cache/rails/cache/javascripts
remote: 11M	/app/tmp/cache/rails/cache/sass
remote: 36K	/app/tmp/cache/rails/cache/sass-preprocessed
remote: 87M	/app/tmp/cache/rails/cache/sprockets-cache
remote: 796K	/app/tmp/cache/rails/cache/templates
```

After this deploy, these asset directories were cached:

```bash
remote: 79M	/tmp/build_8cb204f1ab21372a771e218960ce51cb/tmp/assets
remote: 4.9M	/tmp/build_8cb204f1ab21372a771e218960ce51cb/tmp/javascripts
remote: 11M	/tmp/build_8cb204f1ab21372a771e218960ce51cb/tmp/sass
remote: 36K	/tmp/build_8cb204f1ab21372a771e218960ce51cb/tmp/sass-preprocessed
remote: 48M	/tmp/build_8cb204f1ab21372a771e218960ce51cb/tmp/sprockets-cache
remote: 796K	/tmp/build_8cb204f1ab21372a771e218960ce51cb/tmp/templates
```

This deploy took 20m18s.