### PR TITLE
 FIx reference to the command when a failure occurs with "rake release"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ def commit_and_tag_version(function_name, version)
     fail <<~ERROR
         The following command failed to run:
 
-        #{COMMAND}
+        #{command}
 
         The output captured was:
 


### PR DESCRIPTION
# What does this PR do?

This fixes a bad reference to the command when a failure occurs with "rake release". Without this if something error'd this would print out:

>  NameError: uninitialized constant COMMAND

Now it prints the actual command that it ran that error'd.

## Why was this happening?

I was trying to run "rake release" on `master` and there is a pre-commit hook on the repository to disallow commits to master. This caused the command to fail.